### PR TITLE
correct slow_general_univariate test

### DIFF
--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -293,9 +293,8 @@ def test_issue_9954():
 
 @slow
 def test_slow_general_univariate():
-    r = RootOf(x**5 - x**2 + 1, 0)
-    assert solve(sqrt(x) + 1/root(x, 3) > 1) == \
-        Or(And(S(0) < x, x < r**6), And(r**6 < x, x < oo))
+    assert str(solve(sqrt(x) + 1/root(x, 3) - 2 > 0
+        ).as_set().n(5)) == '(0, 0.37284) U (1.0, +inf)'
 
 
 def test_issue_8545():


### PR DESCRIPTION
The old test was wrong as was confirmed graphically. The solution to the
new expression comes back as a non-RootOf expression which has trouble
computing at low precision. It will be better to send such roots back
as RootOf instances, but that can be done in a subsequent commit.

For the record, here is the evaluation of the interval at different
precisions:

``` python
>>> i=solve(sqrt(x) + 1/root(x, 3) - 2 > 0).as_set()
>>> for n in range(3, 6):
...  print n, i.n(n)
...
3 (0, 0.375) U (1.0, +inf)
4 (0, 0.3727) U (1.0, +inf)
5 (0, 0.37284) U (1.0, +inf)
```

The true answer can be obtained numerically from nsolve:

```
>>> nsolve(sqrt(x) + 1/root(x, 3) - 2, .37)
mpf('0.37284373759817781')
```
